### PR TITLE
altered main command to point to data-es and not data

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mr-emoji",
   "version": "1.1.4",
   "description": "Customizable Slack-like emoji picker for React",
-  "main": "dist/index.js",
+  "main": "dist-es/index.js",
   "module": "dist-es/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I was getting a `not found` error because I couldn't access the files as `dist/index.js` did not exist